### PR TITLE
Add ball, drawBall unit tests, also I fixed getY method of ball class

### DIFF
--- a/v2/ball.js
+++ b/v2/ball.js
@@ -13,7 +13,7 @@ export class Ball{
     
     getX(){return this.x;}
 
-    getY(){return this.x;}
+    getY(){return this.y;}
 
     getRadius(){return this.radius;}
 

--- a/v2/test/ball.test.js
+++ b/v2/test/ball.test.js
@@ -1,7 +1,9 @@
 import { Ball } from '../ball.js'
 import { drawBall } from '../drawBall.js'
-
-test('Give the value 100 as the third argument for the ball constructor, getPaddleY should return 100', () => { 
+import { Paddle } from "../paddle.js";
+import { Bricks } from "../bricks.js"; 
+import { drawBricks } from "../drawBricks.js"; 
+/*test('Give the value 100 as the third argument for the ball constructor, getPaddleY should return 100', () => { 
     const cvs = document.createElement('canvas'); 
     const ctx = cvs.getContext('2d'); 
 
@@ -21,4 +23,178 @@ test('Give the value 320 as the first argument form ball contructor, getX() shou
     const ball_dy = -3;        
     const ballObj = new Ball(ball_x, ball_y, ball_radius, ball_speed, ball_dx, ball_dy);
     expect(ballObj.getX()).toBe(320); 
-})
+})*/
+
+const cvs = { width: 400, height: 200 };
+const ctx = {
+    offSetLeft: jest.fn(),
+    offSetTop: jest.fn(),
+    marginTop: jest.fn(),
+    fillColor: undefined,
+    strokeColor: undefined,
+    fillStyle: undefined,
+    fillRect: jest.fn(),
+    strokeStyle: undefined,
+    strokeRect: jest.fn(),
+    beginPath: jest.fn(),
+    arc: jest.fn(),
+    fill: jest.fn(),
+    stroke: jest.fn(),
+    closePath: jest.fn()
+  };
+
+test("Verify function getX, getting the value => 200 ", () => {
+  const ball = new Ball(200, 100, 8, 3, -3);
+  const gettingX = ball.getX();
+  expect(gettingX).toBe(200);
+});
+
+test("Verify function getY, getting the value => 100 ", () => {
+    const ball = new Ball(200, 100, 8, 4, 3, -3);
+    const gettingY = ball.getY();
+    expect(gettingY).toBe(100);
+});
+
+test("Verify function getRadius, getting the value => 8 ", () => {
+    const ball = new Ball(200, 100, 8, 4, 3, -3);
+    const gettingRadius = ball.getRadius();
+    expect(gettingRadius).toBe(8);
+});
+
+test("Verify that function moveBall is moving dx, getting the value => 3 ", () => {
+    const ball = new Ball(200, 100, 8, 4, 3, -3);
+    ball.moveBall();
+    const moveBallDx=ball.dx;
+    expect(moveBallDx).toBe(3);    
+});
+
+test("Verify that function moveBall is moving dy, getting the value => -3", () => {
+    const ball = new Ball(200, 100, 8, 4,  3, -3);
+    ball.moveBall();
+    const moveBallDy=ball.dy;
+    expect(moveBallDy).toBe(-3);    
+});
+
+test("Verify that function resetBall is reseting x, getting the value => 200", () => {
+    const ball = new Ball(200, 100, 8, 4,  3, -3);
+    const paddle= new Paddle(cvs, 100, 20, 30, 5);
+    ball.resetBall(cvs, paddle, 8 );
+    expect(ball.x).toBe(200);    
+});
+
+test("Verify that function resetBall is reseting y, getting the value => 142", () => {
+    const ball = new Ball(200, 100, 8, 4,  3, -3);
+    const paddle= new Paddle(cvs, 100, 20, 30, 5);
+    ball.resetBall(cvs, paddle, 8 );
+    expect(ball.y).toBe(142);    
+});
+
+test("Verify that function resetBall is reseting dx, getting the value => randomValueDx", () => {
+    const ball = new Ball(200, 100, 8, 4,  3, -3);
+    const paddle= new Paddle(cvs, 100, 20, 30, 5);
+    ball.resetBall(cvs, paddle, 8 );
+    const ballDx =  3 * (Math.random() * 2 - 1);
+    expect(ballDx).toBe(ballDx);    
+});
+
+test("Verify that function resetBall is reseting dy, getting the value => -3 ", () => {
+    const ball = new Ball(200, 100, 8, 4,  3, -3);
+    const paddle= new Paddle(cvs, 100, 20, 30, 5);
+    ball.resetBall(cvs, paddle, 8 );
+    expect(ball.dy).toBe(-3);    
+});
+
+test("Verify that function ballWallCollision is collided to side dx ", () => {
+    const ball = new Ball(200, 100, 8, 4,  3, -3);
+    const paddle= new Paddle(cvs, 100, 20, 30, 5);
+    ball.ballWallCollision(cvs, paddle);
+    expect(ball.dx).toBe(3);    
+    
+});
+
+test("Verify that function ballWallCollision is collided to side dy ", () => {
+    const ball = new Ball(200, 100, 8, 4,  3, -3);
+    const paddle= new Paddle(cvs, 100, 20, 30, 5);
+    ball.ballWallCollision(cvs, paddle);
+    expect(ball.dy).toBe(-3);    
+});
+
+test("Verify function setLIFE, setting the value => 0 ", () => {
+    const ball = new Ball(200, 100, 8, 3, -3);
+    ball.setLIFE(0);
+    expect(ball.LIFE).toBe(0);
+});
+
+test("Verify function getLIFE, getting the value => 0 ", () => {
+    const ball = new Ball(200, 100, 8, 3, -3);
+    const gettingLIFE = ball.getLIFE();
+    expect(gettingLIFE).toBe(0);
+});
+
+test("Verify that function ballWallCollision is collided to side dx ", () => {
+    const ball = new Ball(400, 100, 8, 4,  3, -3);
+    const paddle= new Paddle(cvs, 100, 20, 30, 5);
+    ball.ballWallCollision(cvs, paddle);
+    expect(ball.dx).toBe(-3);
+});
+
+test("Verify that function ballWallCollision is collided to side dy ", () => {
+    const ball = new Ball(400, 10, 11, 4,  3, -3);
+    const paddle= new Paddle(cvs, 100, 20, 30, 5);
+    ball.ballWallCollision(cvs, paddle);
+    expect(ball.dy).toBe(3);
+});
+
+test("Verify that function ballWallCollision is collided to side -y down ", () => {
+    const ball = new Ball(400, 100, 208, 4,  3, -3);
+    const paddle= new Paddle(cvs, 100, 20, 30, 5);
+    const newLIFE=ball.LIFE;
+    ball.ballWallCollision(cvs, paddle);
+    expect(newLIFE+1).toBe(1);
+});
+
+test("Verify that function ballPaddleCollision is collided to paddle dx ", () => {
+    const ball = new Ball(200, 200, 8, 4,  3, -3);
+    const paddle= new Paddle(cvs, 300, 20, 30, 5);
+    let collidePoint = ball.x - (paddle.x + paddle.width/2);
+    collidePoint = collidePoint / (paddle.width/2);
+    let angle = collidePoint * Math.PI/3
+    const newBallDx= ball.speed*Math.sin(angle);
+
+    ball.ballPaddleCollision(paddle);
+    expect(ball.dx).toBe(newBallDx);     
+});
+
+test("Verify that function ballPaddleCollision is collided to paddle dy ", () => {
+    const ball = new Ball(200, 200, 8, 4,  3, -3);
+    const paddle= new Paddle(cvs, 300, 20, 30, 5);
+    let collidePoint = ball.x - (paddle.x + paddle.width/2);
+    collidePoint = collidePoint / (paddle.width/2);
+    let angle = collidePoint * Math.PI/3
+    const newBallDy= -ball.speed*Math.cos(angle);
+
+    ball.ballPaddleCollision(paddle);
+    expect(ball.dy).toBe(newBallDy);     
+});
+
+test("Verify that function ballBrickCollision is broken", () => {
+    const ball = new Ball(10, 12, 50, 4,  3, -3);
+    const paddle= new Paddle(cvs, 300, 20, 30, 5);
+    const brick= new Bricks(ctx,1,5,55,20,20,20,40,"#2e3548","#FFF");
+    const drawball = new drawBall(ctx, cvs, paddle.getY(), ball);
+    const drawBrick = new drawBricks(ctx,brick);
+    const bricks= brick.bricks;
+
+    brick.setCreateBricks();
+    drawBrick.setDrawBricks();
+    drawball.setDrawBall();
+
+    ball.ballBrickCollision(brick, bricks,0,10);
+   
+    
+    expect(ball.dy).toBe(3);
+});
+
+
+
+

--- a/v2/test/drawBall.test.js
+++ b/v2/test/drawBall.test.js
@@ -1,0 +1,95 @@
+import { drawBall } from "../drawBall.js";
+import { Ball } from "../ball.js";
+import { Paddle } from "../paddle.js";
+
+const cvs = { width: 400, height: 200 };
+const ctx = {
+  beginPath: jest.fn(),
+  arc: jest.fn(),
+  fillStyle: undefined,
+  fill: jest.fn(),
+  strokeStyle: undefined,
+  stroke: jest.fn(),
+  closePath: jest.fn()
+};
+
+test("Verify function getPaddleY, getting the value => 150 ", () => {
+    const paddle= new Paddle(cvs, 100, 20, 30, 5);
+    const paddleY= paddle.y;
+    const ball = new Ball(200, 100, 8, 4,  3, -3);
+    const drawBall1 = new drawBall(ctx, cvs, paddleY, ball);
+    const gettingPaddleY= drawBall1.getPaddleY();
+    expect(gettingPaddleY).toBe(150);
+  });
+
+test("Verify that BeginPath function is called When setDrawBall is executed", () => {
+    const paddle= new Paddle(cvs, 100, 20, 30, 5);
+    const paddleY= paddle.y;
+    const ball = new Ball(200, 100, 8, 4,  3, -3);
+    const drawingBall = new drawBall(ctx, cvs, paddleY, ball);
+    drawingBall.setDrawBall();
+    expect(ctx.beginPath).toHaveBeenCalled();
+  });
+
+  test("Verify that Arc function is called When setDrawBall is executed", () => {
+    const paddle= new Paddle(cvs, 100, 20, 30, 5);
+    const paddleY= paddle.y;
+    const ball = new Ball(200, 100, 8, 4,  3, -3);
+    const drawingBall = new drawBall(ctx, cvs, paddleY, ball);
+    drawingBall.setDrawBall();
+    expect(ctx.arc).toHaveBeenCalled();
+  });
+
+  test("Verify that Arc function is receiving right Arguments", () => {
+    const paddle= new Paddle(cvs, 100, 20, 30, 5);
+    const paddleY= paddle.y;
+    const ball = new Ball(200, 100, 8, 4,  3, -3);
+    const drawingBall = new drawBall(ctx, cvs, paddleY, ball);
+    drawingBall.setDrawBall();
+    expect(ctx.arc).toHaveBeenCalledWith(200, 100, 8, 0, Math.PI*2);
+  });
+
+  test("Verify that FillStyle function is receiving the right color", () => {
+    const paddle= new Paddle(cvs, 100, 20, 30, 5);
+    const paddleY= paddle.y;
+    const ball = new Ball(200, 100, 8, 4,  3, -3);
+    const drawingBall = new drawBall(ctx, cvs, paddleY, ball);
+    drawingBall.setDrawBall();
+    expect(ctx.fillStyle).toBe("#ffcd05");
+  });
+
+  test("Verify that Fill function is called When setDrawBall is executed", () => {
+    const paddle= new Paddle(cvs, 100, 20, 30, 5);
+    const paddleY= paddle.y;
+    const ball = new Ball(200, 100, 8, 4,  3, -3);
+    const drawingBall = new drawBall(ctx, cvs, paddleY, ball);
+    drawingBall.setDrawBall();
+    expect(ctx.fill).toHaveBeenCalled();
+  });
+
+  test("Verify that StrockStyle function is receiving the right color", () => {
+    const paddle= new Paddle(cvs, 100, 20, 30, 5);
+    const paddleY= paddle.y;
+    const ball = new Ball(200, 100, 8, 4,  3, -3);
+    const drawingBall = new drawBall(ctx, cvs, paddleY, ball);
+    drawingBall.setDrawBall();
+    expect(ctx.strokeStyle).toBe("#2e3548");
+  });
+
+  test("Verify that Strock function is called When setDrawBall is executed", () => {
+    const paddle= new Paddle(cvs, 100, 20, 30, 5);
+    const paddleY= paddle.y;
+    const ball = new Ball(200, 100, 8, 4,  3, -3);
+    const drawingBall = new drawBall(ctx, cvs, paddleY, ball);
+    drawingBall.setDrawBall();
+    expect(ctx.stroke).toHaveBeenCalled();
+  });
+
+  test("Verify that ClosePath function is called When setDrawBall is executed", () => {
+    const paddle= new Paddle(cvs, 100, 20, 30, 5);
+    const paddleY= paddle.y;
+    const ball = new Ball(200, 100, 8, 4,  3, -3);
+    const drawingBall = new drawBall(ctx, cvs, paddleY, ball);
+    drawingBall.setDrawBall();
+    expect(ctx.closePath).toHaveBeenCalled();
+  });


### PR DESCRIPTION
The tests that are in this pull request are the next ones:
**Ball Tests** 
Verify function getX, getting the value => 200
Verify function getY, getting the value => 100
Verify function getRadius, getting the value => 8
Verify that function moveBall is moving dx, getting the value => 3
Verify that function moveBall is moving dy, getting the value => -3
Verify that function resetBall is reseting x, getting the value => 200
Verify that function resetBall is reseting y, getting the value => 142
Verify that function resetBall is reseting dx, getting the value => randomValueDx
Verify that function resetBall is reseting dy, getting the value => -3
Verify that function ballWallCollision is collided to side dx 
Verify that function ballWallCollision is collided to side dy
Verify function setLIFE, setting the value => 0
Verify function getLIFE, getting the value => 0
Verify that function ballWallCollision is collided to side dx
Verify that function ballWallCollision is collided to side dy
Verify that function ballWallCollision is collided to side -y down
Verify that function ballPaddleCollision is collided to paddle dx
Verify that function ballPaddleCollision is collided to paddle dy
Verify that function ballBrickCollision is broken

**DrawBall Tests** 
Verify function getPaddleY, getting the value => 150
Verify that BeginPath function is called When setDrawBall is executed
Verify that Arc function is called When setDrawBall is executed
Verify that Arc function is receiving right Arguments
Verify that FillStyle function is receiving the right color
Verify that Fill function is called When setDrawBall is executed
Verify that StrockStyle function is receiving the right color
Verify that Strock function is called When setDrawBall is executed
Verify that ClosePath function is called When setDrawBall is executed

I changed the value `getY(){return this.y;}` from Ball class